### PR TITLE
Avoid Unable to connect: ssh: must specify HostKeyCallback

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -22,6 +22,7 @@ const (
 	//Type authentication login in ssh, it can using password or using public-private key
 	SSHAuthType_Password SSHAuthTypeEnum = iota
 	SSHAuthType_Certificate
+	SSHAuthType_NoPassword
 )
 
 type SshSetting struct {
@@ -64,6 +65,11 @@ func (S *SshSetting) Connect() (*ssh.Client, error) {
 			Auth: []ssh.AuthMethod{
 				PublicKeyFile(S.SSHKeyLocation),
 			},
+		}
+	} else if S.SSHAuthType == SSHAuthType_NoPassword {
+		cfg = &ssh.ClientConfig{
+			User:            S.SSHUser,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}
 	} else {
 		cfg = &ssh.ClientConfig{

--- a/ssh.go
+++ b/ssh.go
@@ -70,6 +70,8 @@ func (S *SshSetting) Connect() (*ssh.Client, error) {
 		cfg = &ssh.ClientConfig{
 			User:            S.SSHUser,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+      Auth:[]ssh.AuthMethod{
+      }
 		}
 	} else {
 		cfg = &ssh.ClientConfig{

--- a/ssh.go
+++ b/ssh.go
@@ -6,13 +6,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type SSHAuthTypeEnum int
@@ -58,14 +59,16 @@ func (S *SshSetting) Connect() (*ssh.Client, error) {
 
 	if S.SSHAuthType == SSHAuthType_Certificate {
 		cfg = &ssh.ClientConfig{
-			User: S.SSHUser,
+			User:            S.SSHUser,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 			Auth: []ssh.AuthMethod{
 				PublicKeyFile(S.SSHKeyLocation),
 			},
 		}
 	} else {
 		cfg = &ssh.ClientConfig{
-			User: S.SSHUser,
+			User:            S.SSHUser,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 			Auth: []ssh.AuthMethod{
 				ssh.Password(S.SSHPassword),
 			},

--- a/ssh.go
+++ b/ssh.go
@@ -70,8 +70,7 @@ func (S *SshSetting) Connect() (*ssh.Client, error) {
 		cfg = &ssh.ClientConfig{
 			User:            S.SSHUser,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-      Auth:[]ssh.AuthMethod{
-      }
+      Auth:[]ssh.AuthMethod{}
 		}
 	} else {
 		cfg = &ssh.ClientConfig{


### PR DESCRIPTION
added HostKeyCallback: ssh.InsecureIgnoreHostKey() to ssh.ClientConfig to avoid HostKeyCallBack error